### PR TITLE
テキスト内で短い改行があると、必要以上に省略表示される問題を修正

### DIFF
--- a/TruncatedText/ContentView.swift
+++ b/TruncatedText/ContentView.swift
@@ -1,18 +1,28 @@
 import SwiftUI
 
 struct ContentView: View {
-    let text = "吾輩は猫である。名前はまだ無い。どこで生れたかとんと見当がつかぬ。何でも薄暗いじめじめした所でニャーニャー泣いていた事だけは記憶している。吾輩はここで始めて人間というものを見た。"
+    let text = "吾輩は猫である。\n名前はまだ無い。\nどこで生れたかとんと見当がつかぬ。\n何でも薄暗いじめじめした所でニャーニャー泣いていた事だけは記憶している。\n吾輩はここで始めて人間というものを見た。"
 
     var body: some View {
-        VStack(spacing: 40) {
-            Text(text)
-                .lineLimit(3)
+        GeometryReader { proxy in
+            VStack(alignment: .leading, spacing: 40) {
+                Text(text)
+                    .lineLimit(2)
+                
+                // 内部のGeometryProxyでサイズを計測する
+                TrancatedText(text,
+                              lineLimit: 2,
+                              ellipsis: .init(text: "More", color: .blue))
 
-            TrancatedText(text,
-                          lineLimit: 3,
-                          ellipsis: .init(text: "More", color: .blue))
+                // GeometryProxyを渡して、親Viewのwidthを使ってサイズを計測する
+                TrancatedText(text,
+                              lineLimit: 2,
+                              ellipsis: .init(text: "More", color: .blue),
+                              proxy: proxy)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
         }
-        .padding()
     }
 }
 


### PR DESCRIPTION
## 原因
テキスト内で短い改行があると、計測用のレイヤーでlineLimitを適用すると、GeometryProxy.size.widthが小さくなってしまうので、末尾のテキストが必要以上に削られた。

## 修正内容
親ViewからGeometryProxyを渡して、そのwidthを利用して描画領域を確保しながら計測することで、必要以上に省略される問題を解決。

## キャプチャ
<img src="https://github.com/TAATHub/swiftui-truncated-text/assets/83394375/b573d5e4-e6c6-4926-8a8a-99b6d07abc15" width="480">